### PR TITLE
[BOP-1192] Fetch mkectl latest version from mke-release public repo

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -113,9 +113,27 @@ main() {
   echo "#########################"
 
   if [ -z "${MKECTL_VERSION}" ]; then
-    echo "Using default mkectl version v4.0.0-rc.5"
-    MKECTL_VERSION=v4.0.0-rc.5
+      # Determine the version
+      # Get information about the latest release and pull version from the tag
+      MKECTL_VERSION=$(curl -s https://api.github.com/repos/mirantiscontainers/mke-release/releases/latest | grep '"tag_name"' | tr -s ' ' | cut -d ' ' -f 3 | cut -d '"' -f 2)
+
+      if [ -z "${MKECTL_VERSION}" ]; then
+        echo "Failed to retrieve the latest release version."
+        exit 1
+      fi
+
+      echo "MKECTL_VERSION not set, using latest release: ${MKECTL_VERSION}"
+# TODO: Uncomment the following block after the mke-release starts getting all the releases
+#  else
+#      # Make sure it is a valid version
+#      if ! curl -s https://api.github.com/repos/mirantiscontainers/mke-release/releases | grep -q "\"tag_name\": \"${MKECTL_VERSION}\""; then
+#        echo "Invalid version specified: ${MKECTL_VERSION}"
+#        exit 1
+#      fi
+#
+#      echo "Using specified version: ${MKECTL_VERSION}"
   fi
+
   printf "\n"
 
 


### PR DESCRIPTION
# Description

This PR adds support for automatically fetching mkectl latest version using mke-release latest tag. We don't need to update install.sh everytime an mke release is made.

# JIRA ticket
https://mirantis.jira.com/browse/BOP-1192

# Manual Testing

1) **Without setting MKECTL_VERSION explicitly** => The script should fetch the latest tag from mke-release repo and use it for mkectl_version.

```
sudo ./install.sh
Password:


Step 1/3 : Install k0sctl
#########################
Using default k0sctl version 0.19.0
Downloading k0sctl from URL: https://github.com/k0sproject/k0sctl/releases/download/v0.19.0/k0sctl-darwin-arm64
k0sctl is now executable in /usr/local/bin


Step 2/3 : Install kubectl
#########################
The connection to the server localhost:8080 was refused - did you specify the right host or port?
kubectl version  v1.30.0 already exists.


Step 3/3 : Install mkectl
#########################
MKECTL_VERSION not set, using latest release: v4.0.0-test-mke-release

Downloading mkectl
x mkectl
mkectl is now executable in /usr/local/bin
```

2) ** Set a valid MKECTL_VERSION explicitly** => The script should use the provided tag to install mkectl.

```
udo MKECTL_VERSION=v4.0.0-test-mke-release ./install.sh
Password:


Step 1/3 : Install k0sctl
#########################
Using default k0sctl version 0.19.0
Downloading k0sctl from URL: https://github.com/k0sproject/k0sctl/releases/download/v0.19.0/k0sctl-darwin-arm64
k0sctl is now executable in /usr/local/bin


Step 2/3 : Install kubectl
#########################
The connection to the server localhost:8080 was refused - did you specify the right host or port?
kubectl version  v1.30.0 already exists.


Step 3/3 : Install mkectl
#########################
Using specified version: v4.0.0-test-mke-release

Downloading mkectl
Checking if the specified version exists...
x mkectl
mkectl is now executable in /usr/local/bin
```

3) ** Set a invalid MKECTL_VERSION explicitly** => The script should use the provided tag to install mkectl.

```
sudo MKECTL_VERSION=v4.0.1-test-mke-release ./install.sh
Password:


Step 1/3 : Install k0sctl
#########################
Using default k0sctl version 0.19.0
Downloading k0sctl from URL: https://github.com/k0sproject/k0sctl/releases/download/v0.19.0/k0sctl-darwin-arm64
k0sctl is now executable in /usr/local/bin


Step 2/3 : Install kubectl
#########################
The connection to the server localhost:8080 was refused - did you specify the right host or port?
kubectl version  v1.30.0 already exists.


Step 3/3 : Install mkectl
#########################
Using specified version: v4.0.1-test-mke-release

Downloading mkectl
Checking if the specified version exists...
Error: The specified version v4.0.1-test-mke-release does not exist or is invalid.
```