### PR TITLE
Add v4.0.1-beta.1 to release matrix

### DIFF
--- a/release-matrix/release-matrix.json
+++ b/release-matrix/release-matrix.json
@@ -1,10 +1,18 @@
 [
   {
+    "mkeReleaseVersion": "v4.0.1-beta.1",
+    "blueprintOperatorVersion": "v1.0.20",
+    "mkeOperatorVersion": "v1.2.4",
+    "k0sVersion": "v1.31.1+k0s.1",
+    "isLatest": true,
+    "minimumMkectlVersion": "v4.0.1-beta.1"
+  },
+  {
     "mkeReleaseVersion": "v4.0.1-alpha.2",
     "blueprintOperatorVersion": "v1.0.18",
     "mkeOperatorVersion": "v1.2.1",
     "k0sVersion": "v1.31.1+k0s.1",
-    "isLatest": true,
+    "isLatest": false,
     "minimumMkectlVersion": "v4.0.1-alpha.2"
   },
   {


### PR DESCRIPTION
Add a new entry for `v4.0.1-beta.1` release.