### PR TITLE
Update release matrix BOP-1800

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 .PHONY: install-jsonschema validate-json
 
 install-jsonschema:
-	pip3 install jsonschema
+	python3 -m venv .venv
+	. .venv/bin/activate && pip install jsonschema
 
 validate-json: install-jsonschema
-	python3 release-matrix/validate_json.py release-matrix/release-matrix.json release-matrix/release-matrix-schema.json
+	. .venv/bin/activate && python3 release-matrix/validate_json.py release-matrix/release-matrix.json release-matrix/release-matrix-schema.json

--- a/release-matrix/release-matrix-schema.json
+++ b/release-matrix/release-matrix-schema.json
@@ -10,8 +10,8 @@
         "description": "The MKE 4 minor/patch version that this entry applies to",
         "type": "string"
       },
-      "blueprintOperatorVersion": {
-        "description": "Blueprint operator version for this MKE 4 release",
+      "k0rdentVersion": {
+        "description": "K0rdent version for this MKE 4 release",
         "type": "string"
       },
       "mkeOperatorVersion": {
@@ -31,6 +31,6 @@
         "description": "Minimum mkectl version required to install this MKE 4 release"
       }
     },
-    "required": ["mkeReleaseVersion", "blueprintOperatorVersion", "mkeOperatorVersion", "k0sVersion", "minimumMkectlVersion"]
+    "required": ["mkeReleaseVersion", "k0rdentVersion", "mkeOperatorVersion", "k0sVersion", "minimumMkectlVersion"]
   }
 }

--- a/release-matrix/release-matrix.json
+++ b/release-matrix/release-matrix.json
@@ -1,42 +1,18 @@
 [
   {
-    "mkeReleaseVersion": "v4.0.1-rc.2",
-    "blueprintOperatorVersion": "v1.0.21",
-    "mkeOperatorVersion": "v1.2.6",
-    "k0sVersion": "v1.31.1+k0s.1",
+    "mkeReleaseVersion": "v4.1.1-alpha.1",
+    "k0rdentVersion": "v0.2.0-alpha4",
+    "mkeOperatorVersion": "v1.3.2",
+    "k0sVersion": "v1.32.3+k0s.0",
     "isLatest": true,
-    "minimumMkectlVersion": "v4.0.1-rc.2"
-  },  
-  {
-    "mkeReleaseVersion": "v4.0.1-rc.1",
-    "blueprintOperatorVersion": "v1.0.21",
-    "mkeOperatorVersion": "v1.2.5",
-    "k0sVersion": "v1.31.1+k0s.1",
-    "isLatest": false,
-    "minimumMkectlVersion": "v4.0.1-rc.1"
-  },  
-  {
-    "mkeReleaseVersion": "v4.0.1-beta.1",
-    "blueprintOperatorVersion": "v1.0.20",
-    "mkeOperatorVersion": "v1.2.4",
-    "k0sVersion": "v1.31.1+k0s.1",
-    "isLatest": false,
-    "minimumMkectlVersion": "v4.0.1-beta.1"
+    "minimumMkectlVersion": "v4.1.1-alpha.1"
   },
   {
-    "mkeReleaseVersion": "v4.0.1-alpha.2",
-    "blueprintOperatorVersion": "v1.0.18",
-    "mkeOperatorVersion": "v1.2.1",
-    "k0sVersion": "v1.31.1+k0s.1",
+    "mkeReleaseVersion": "v4.1.0",
+    "k0rdentVersion": "v0.2.0-alpha4",
+    "mkeOperatorVersion": "v1.3.0",
+    "k0sVersion": "v1.32.3+k0s.0",
     "isLatest": false,
-    "minimumMkectlVersion": "v4.0.1-alpha.2"
-  },
-  {
-    "mkeReleaseVersion": "v4.0.0",
-    "blueprintOperatorVersion": "v1.0.17",
-    "mkeOperatorVersion": "v1.0.0",
-    "k0sVersion": "v1.31.1+k0s.1",
-    "isLatest": false,
-    "minimumMkectlVersion": "v4.0.0"
+    "minimumMkectlVersion": "v4.1.0"
   }
 ]


### PR DESCRIPTION
Update release matrix:
- remove unneeded mke versions
- replace blueprint operator version with k0rdent

Fix issues verification
- replace blueprintOperatorVersion with k0rdentVersion as required field
- fix download of jsonschema to use venv to work with recent python installations