### PR TITLE
[BOP-1800] Add MOP helm chart to release matrix

### DIFF
--- a/release-matrix/release-matrix-schema.json
+++ b/release-matrix/release-matrix-schema.json
@@ -14,9 +14,13 @@
         "description": "K0rdent version for this MKE 4 release",
         "type": "string"
       },
-      "mkeOperatorVersion": {
+      "mkeOperatorImageVersion": {
         "type": "string",
-        "description": "MKE Operator version for this MKE 4 release"
+        "description": "MKE Operator Image version for this MKE 4 release"
+      },
+      "mkeOperatorChartVersion": {
+        "type": "string",
+        "description": "MKE Operator Helm Chart version for this MKE 4 release"
       },
       "k0sVersion": {
         "type": "string",
@@ -31,6 +35,6 @@
         "description": "Minimum mkectl version required to install this MKE 4 release"
       }
     },
-    "required": ["mkeReleaseVersion", "k0rdentVersion", "mkeOperatorVersion", "k0sVersion", "minimumMkectlVersion"]
+    "required": ["mkeReleaseVersion", "k0rdentVersion", "mkeOperatorImageVersion", "mkeOperatorChartVersion", "k0sVersion", "minimumMkectlVersion"]
   }
 }

--- a/release-matrix/release-matrix.json
+++ b/release-matrix/release-matrix.json
@@ -2,7 +2,8 @@
   {
     "mkeReleaseVersion": "v4.1.1-alpha.1",
     "k0rdentVersion": "v0.2.0-alpha4",
-    "mkeOperatorVersion": "v1.3.2",
+    "mkeOperatorImageVersion": "v1.3.2",
+    "mkeOperatorChartVersion": "1.1.4",
     "k0sVersion": "v1.32.3+k0s.0",
     "isLatest": true,
     "minimumMkectlVersion": "v4.1.1-alpha.1"
@@ -10,7 +11,8 @@
   {
     "mkeReleaseVersion": "v4.1.0",
     "k0rdentVersion": "v0.2.0-alpha4",
-    "mkeOperatorVersion": "v1.3.0",
+    "mkeOperatorImageVersion": "v1.3.0",
+    "mkeOperatorChartVersion": "1.0.0",
     "k0sVersion": "v1.32.3+k0s.0",
     "isLatest": false,
     "minimumMkectlVersion": "v4.1.0"


### PR DESCRIPTION
MOP helm chart is also specific to each MKE release so needs to be included in release matrix.