### PR TITLE
Fix install.sh exit code always exits 1 when downloading mkectl

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -65,7 +65,7 @@ download_mkectl() {
  # Verify the file is a valid gzip archive
  if [ -s /tmp/mkectl.tar.gz ]; then
    # Extract the downloaded file
-   tar -xvzf /tmp/mkectl.tar.gz -C "$installPath" && echo "mkectl is now executable in $installPath" || echo "Error: Downloaded file is not a valid gzip archive" >&2 && exit 1
+   tar -xvzf /tmp/mkectl.tar.gz -C "$installPath" && echo "mkectl is now executable in $installPath" || { echo "Error: Downloaded file is not a valid gzip archive" >&2; exit 1; }
  else
    echo "Error: Downloaded file is empty." >&2
    exit 1


### PR DESCRIPTION
`mkectl` binary download always returns exit code 1 in install.sh. This causes issues for certain automation, for example I am trying to download a `4.1.0` binary in Dockerfile for testing and this causes the image build to always fail.

See:
```
sudo MKECTL_VERSION=v4.1.0 /bin/sh -c "$(curl -fsSL https://raw.githubusercontent.com/MirantisContainers/mke-release/refs/heads/main/install.sh)"

Using specified version: v4.1.0


Install mkectl
#########################

Checking if the specified version exists...
Downloading mkectl...
mkectl
mkectl is now executable in /usr/local/bin
ubuntu@ip-172-31-45-250:~$ echo $?
1
```

Exit code is 1 despite successful download.