### PR TITLE
Update release-matrix.json

### DIFF
--- a/release-matrix/release-matrix.json
+++ b/release-matrix/release-matrix.json
@@ -1,7 +1,7 @@
 [
   {
     "mkeReleaseVersion": "v4.1.1-beta.1",
-    "k0rdentVersion": "1.1.0-rc.5",
+    "k0rdentVersion": "1.1.0-rc5",
     "mkeOperatorImageVersion": "v1.4.0",
     "mkeOperatorChartVersion": "3.2.0",
     "k0sVersion": "v1.32.6+k0s.0",


### PR DESCRIPTION
The tag for k0rdent-enterprise version is incorrect:

```
oras manifest fetch registry.mirantis.com/k0rdent-enterprise/charts/k0rdent-enterprise:1.1.0-rc.5

Error response from registry: failed to fetch the content of "registry.mirantis.com/k0rdent-enterprise/charts/k0rdent-enterprise:1.1.0-rc.5": registry.mirantis.com/k0rdent-enterprise/charts/k0rdent-enterprise:1.1.0-rc.5: not found
tpolkowski@Thomas-Polkowski-MacBook-Pro-16-inch-2021- mke3 %  oras repo tags registry.mirantis.com/k0rdent-enterprise/charts/k0rdent-enterprise

1.0.0
1.0.0-rc1
1.0.0-rc2
1.0.0-rc3
1.0.0-rc4
1.0.0-rc5
1.0.0-rc6
1.0.0-rc7
1.1.0-alpha1
1.1.0-alpha2
1.1.0-rc1
1.1.0-rc10
1.1.0-rc11
1.1.0-rc12
1.1.0-rc13
1.1.0-rc2
1.1.0-rc3
1.1.0-rc4
1.1.0-rc5
```