### PR TITLE
bump release matrix to v4.1.1

### DIFF
--- a/release-matrix/release-matrix.json
+++ b/release-matrix/release-matrix.json
@@ -1,12 +1,12 @@
 [
   {
-    "mkeReleaseVersion": "v4.1.1-rc.7",
+    "mkeReleaseVersion": "v4.1.1",
     "k0rdentVersion": "1.1.0",
     "mkeOperatorImageVersion": "v1.4.5",
     "mkeOperatorChartVersion": "3.4.1",
     "k0sVersion": "v1.32.6+k0s.0",
     "isLatest": true,
-    "minimumMkectlVersion": "v4.1.1-rc.7",
+    "minimumMkectlVersion": "v4.1.1",
     "network": {
       "calico": {
         "oss": {


### PR DESCRIPTION
Bumping for the 4.1.1 GA release. The release will be using the same tag as the latest rc release for this version - see https://github.com/MirantisContainers/mke-release/pull/29